### PR TITLE
Update thrift tracker import path

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_go_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_go_generator.cc
@@ -62,7 +62,7 @@ static const string endl = "\n"; // avoid ostream << std::endl flushes
 bool format_go_output(const string& file_path);
 
 const string DEFAULT_THRIFT_IMPORT = "github.com/apache/thrift/lib/go/thrift";
-const string DEFAULT_THRIFT_TRACKER_IMPORT = "github.com/eleme/thrift-tracker";
+const string DEFAULT_THRIFT_TRACKER_IMPORT = "git.elenet.me/arch/thrift-tracker";
 static std::string package_flag;
 
 /**


### PR DESCRIPTION
`github.com/eleme/thrift-tracker` is deprecated, use `git.elenet.me/arch/thrift-tracker` instead.